### PR TITLE
Make AbstractSerial begin and getStream methods pure virtual

### DIFF
--- a/src/Serials.h
+++ b/src/Serials.h
@@ -15,8 +15,8 @@ namespace Serials {
   // just to satisfy linker in gcc I needed to add empty parentheses to other virtual methods...
   class AbstractSerial {
   public:
-    virtual void begin(int baudRate) {};
-    virtual Stream *getStream() {};
+    virtual void begin(int baudRate) = 0;
+    virtual Stream *getStream() = 0;
     virtual ~AbstractSerial() {};
   };
 


### PR DESCRIPTION
After #8, warning was introduced:

```
In file included from .piolibdeps/Nova Fitness Sds dust sensors library/src/SdsDustSensor.h:31:0,
from src/pm_sensor/sensor_pm_sds011.h:2,
from src/main.cpp:13:
.piolibdeps/Nova Fitness Sds dust sensors library/src/Serials.h: In member function 'virtual Stream* Serials::AbstractSerial::getStream()':
.piolibdeps/Nova Fitness Sds dust sensors library/src/Serials.h:19:34: warning: no return statement in function returning non-void [-Wreturn-type]
virtual Stream *getStream() {};
^
```

I think the idea was to make these methods pure virtual, without default implementation `{}` (which does not return proper `Stream` in case of `getStream`).