### PR TITLE
Add option for custom rxPin and txPin with HardwareSerial (e.g. for ESP32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ sds.begin(); // you can pass custom baud rate as parameter (9600 by default)
 SdsDustSensor sds(Serial1); // passing HardwareSerial as parameter, you can tune retry mechanism with additional parameters: retryDelayMs and maxRetriesNotAvailable
 sds.begin(); // you can pass custom baud rate as parameter (9600 by default)
 // or you can pass custom rxPin and txPin to HardwareSerial, if your board (e.g. ESP32) supports remapping of GPIOs to Serial
-// sds.begin(9600, SERIAL_8N1, SDS_RX, SDS_TX);
+// sds.begin(9600, SERIAL_8N1, rxPin, txPin);
 ```
 
 ## Supported operations

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ sds.begin(); // you can pass custom baud rate as parameter (9600 by default)
 ```arduino
 SdsDustSensor sds(Serial1); // passing HardwareSerial as parameter, you can tune retry mechanism with additional parameters: retryDelayMs and maxRetriesNotAvailable
 sds.begin(); // you can pass custom baud rate as parameter (9600 by default)
+// or you can pass custom rxPin and txPin to HardwareSerial, if your board (e.g. ESP32) supports remapping of GPIOs to Serial
+// sds.begin(9600, SERIAL_8N1, SDS_RX, SDS_TX);
 ```
 
 ## Supported operations

--- a/src/SdsDustSensor.h
+++ b/src/SdsDustSensor.h
@@ -72,9 +72,9 @@ public:
     }
   }
 
-  void begin(int baudRate = 9600) {
-    abstractSerial->begin(baudRate);
-  }
+  void begin(int baudRate = 9600, uint32_t config = SERIAL_8N1, int pinRx = -1, int pinTx = -1) {
+      abstractSerial->begin(baudRate, config, pinRx, pinTx);
+    }
 
   byte *getLastResponse() {
     return response;

--- a/src/Serials.h
+++ b/src/Serials.h
@@ -17,7 +17,7 @@ namespace Serials {
   // just to satisfy linker in gcc I needed to add empty parentheses to other virtual methods...
   class AbstractSerial {
   public:
-    virtual void begin(int baudRate) = 0;
+    virtual void begin(int baudRate, uint32_t config, int pinRx, int pinTx) = 0;
     virtual Stream *getStream() = 0;
     virtual ~AbstractSerial() {};
   };
@@ -25,8 +25,8 @@ namespace Serials {
   struct Hardware: public AbstractSerial {
     Hardware(HardwareSerial &serial): serial(serial) {}
 
-    void begin(int baudRate) {
-      serial.begin(baudRate);
+    void begin(int baudRate = 9600, uint32_t config = SERIAL_8N1, int pinRx = -1, int pinTx = -1) {
+      serial.begin(baudRate, config, pinRx, pinTx);
     }
 
     Stream *getStream() {
@@ -40,7 +40,7 @@ namespace Serials {
   struct Software: public AbstractSerial {
     Software(SoftwareSerial &serial): serial(serial) {}
 
-    void begin(int baudRate) {
+    void begin(int baudRate = 9600, uint32_t config = SERIAL_8N1, int pinRx = -1, int pinTx = -1) {
       serial.begin(baudRate);
     }
 
@@ -61,8 +61,8 @@ namespace Serials {
       }
     }
 
-    void begin(int baudRate) {
-      serial->begin(baudRate);
+    void begin(int baudRate = 9600, uint32_t config = SERIAL_8N1, int pinRx = -1, int pinTx = -1) {
+      serial.begin(baudRate);
     }
 
     Stream *getStream() {


### PR DESCRIPTION
ESP32 boards support remapping of GPIO pins to Serial ports (UART0/1/2).

This PR enhances API in Serial.h with an option to pass custom rxPin and txPin to HardwareSerial. It keeps all usage options of the former API (i.e. for using SoftwareSerial), so this change shouldn't break any code created before this PR.